### PR TITLE
No loading animation.

### DIFF
--- a/app.js
+++ b/app.js
@@ -201,7 +201,7 @@ $(document).on("ready", function()
 function search()
 {
 	keyword = $("#s").val();
-	$("#i").attr("src", "load.gif");
+	$("#i").attr("src", "");
 	$("#scene").show();
 	url = translate_endpoint + "/" + api_version + "/gifs/translate?s=" + encodeURIComponent(keyword) + "&api_key=" + config.key;
 	console.log(url);


### PR DESCRIPTION
On slower internet connections the pacman loading animation makes the app feel slower by only showing the gif after it's fully loaded. This is nice because when the gif does display, it plays instantly. On faster internet connections this isn't an issue. Here's an example: 

**With loading animation:**
![](https://cloudup.com/iuXYy1ng4nI+)
**Without loading animation:**
![](https://cloudup.com/iNUipTPBG86+)

I'm not sure what to do here, I may make it configurable. 